### PR TITLE
Appended overwrite parameter for function call

### DIFF
--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -220,7 +220,7 @@ function Publish-SsrsFolder()
             }
         }
 
-        Set-SecurityPolicy -Proxy $Proxy -Folder $currentFolder -RoleAssignments $Folder.RoleAssignments -InheritParentSecurity:$Folder.InheritParentSecurity -Overwrite
+        Set-SecurityPolicy -Proxy $Proxy -Folder $currentFolder -RoleAssignments $Folder.RoleAssignments -InheritParentSecurity:$Folder.InheritParentSecurity -Overwrite:$Overwrite
 
         foreach($folder in $Folder.Folders)
         {


### PR DESCRIPTION
This should fix issue #58 where an parameter is not correctly given to a function call of Set-SecurityPolicy